### PR TITLE
Implement death when out of bounds

### DIFF
--- a/library/WaterWars/Core/Game/Constants.hs
+++ b/library/WaterWars/Core/Game/Constants.hs
@@ -13,3 +13,6 @@ playerHeadHeight = 1 / 2 * defaultPlayerHeight
 
 shootCooldown :: Int
 shootCooldown = 50
+
+outOfBoundsTolerance :: Float
+outOfBoundsTolerance = 5


### PR DESCRIPTION
Fixes #9. A check is added that players die when far out of bounds of the map.